### PR TITLE
Update Christophe Porteneuve profile as he's at Doctolib now

### DIFF
--- a/data/speakers/christophe_porteneuve.yml
+++ b/data/speakers/christophe_porteneuve.yml
@@ -1,14 +1,15 @@
 ---
 key: christophe_porteneuve
 name: Christophe Porteneuve
-company: Delicious Insights
-companyLogo: /images/partners/delicious_insights.png
+company: Doctolib
+# Can be downloaded as per your needs at https://about.doctolib.fr/kit-presse/
+companyLogo: /images/partners/doctolib.png
 city: Paris, France
 photoUrl: https://cdn.delicious-insights.com/chris-avatar-funky-bg.png
 socials:
   twitter: porteneuve
   github: '@tdd'
 bio: |-
-  Christophe est développeur web à titre pro depuis 1995, et fait de la R&D, de la formation pro et des talks en conférence depuis 1996. Ancien core team de Prototype.js et script.aculo.us, ancien contributeur à Ruby on Rails et à Node.js, traducteur FR des docs de React et contributeur occasionnel à JavaScript, il est le fondateur et CTO de Delicious Insights, véritable référence dans la formation pro de pointe sur l'univers du dev web : Git, React / PWA, Node.js, JS pur, etc.
+  Christophe est développeur web à titre pro depuis 1995, et fait de la R&D, de la formation pro et des talks en conférence depuis 1996. Ancien core team de Prototype.js et script.aculo.us, ancien contributeur à Ruby on Rails et à Node.js, traducteur FR des docs de React et contributeur occasionnel à JavaScript, il a fondé et dirigé Delicious Insights pendant 13 ans avant de prendre la tête du frontend chez Doctolib fin 2023.
 
   Il habite près de Paris avec sa femme et ses deux fils.


### PR DESCRIPTION
Hey team!

Just realized my Conference-Hall profile wasn't up-to-date. Updated it there and sync'ing it here.

You might need to download Doctolib's logo and put it in your logo folder, if not already there. The YAML has a comment with a link towards the official logo download area.

Cheers!